### PR TITLE
Add workflow stubs, for imminent development

### DIFF
--- a/.github/workflows/build_and_publish_all_images.yaml
+++ b/.github/workflows/build_and_publish_all_images.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_call
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'

--- a/.github/workflows/build_and_publish_changed_images.yaml
+++ b/.github/workflows/build_and_publish_changed_images.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_call
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_call
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'

--- a/.github/workflows/on_manual_build_all.yaml
+++ b/.github/workflows/on_manual_build_all.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_dispatch
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'

--- a/.github/workflows/on_manual_build_changed.yaml
+++ b/.github/workflows/on_manual_build_changed.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_dispatch
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'

--- a/.github/workflows/on_release_tag.yaml
+++ b/.github/workflows/on_release_tag.yaml
@@ -1,0 +1,10 @@
+name: Stub
+
+on: workflow_dispatch
+
+jobs:
+
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'stub'


### PR DESCRIPTION
This is one approach to solving the "workflows must be on master before they can be tested" problem that #23 is currently facing.