### PR TITLE
Pass xpra resize-display arg, default value set to 'yes'

### DIFF
--- a/images/xpra/entrypoint.sh
+++ b/images/xpra/entrypoint.sh
@@ -113,7 +113,7 @@ echo "Starting Xpra"
 sudo mkdir -p /var/log/xpra
 sudo chmod 777 /var/log/xpra
 (xpra ${XPRA_START:-"start"} ${DISPLAY} \
-    --resize-display=yes \
+    --resize-display=${XPRA_RESIZE_DISPLAY:-"yes"} \
     --user=app \
     --bind-tcp=0.0.0.0:${XPRA_PORT:-8082} \
     --html=on \


### PR DESCRIPTION
Resize the virtual display to match the resolution of the client currently connected. This only applies to the start and start-desktop subcommands. If a resolution is given, this will be the initial resolution of the display and the display will be resizable. 

Parameter
```
XPRA_RESIZE_DISPLAY: yes|no|WIDTHxHEIGHT
Default value: yes
```

Example - Configure XGA resolution
```yml
 spec:
   appEnv:
   - name: XPRA_RESIZE_DISPLAY
     value: "XGA"
```

A set of pre-defined aliases can also be used: 

```python
RESOLUTION_ALIASES = {
   "QVGA"  : (320, 240),
   "VGA"   : (640, 480),
   "SVGA"  : (800, 600),
   "XGA"   : (1024, 768),
   "1080P" : (1920, 1080),
   "FHD"   : (1920, 1080),
   "4K"    : (3840, 2160),
   "5K"    : (5120, 2880),
   "8K"    : (7680, 4320),
   }
```
