### PR TITLE
Introduce enableSudo param to control whether the desktop container can gain sudo privileges.

### DIFF
--- a/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-deploy.yaml.tmpl
+++ b/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-deploy.yaml.tmpl
@@ -19,6 +19,13 @@
   {{- $watchdogImage = .AppParams.watchdogImage}}
 {{- end}}
 
+{{- $enableSudo := true}}
+{{- if .AppParams.enableSudo }}
+  {{- if eq .AppParams.enableSudo "false"}}
+    {{- $enableSudo = false }}
+  {{- end}}
+{{- end}}
+
 ###
 # TODO: figure out how to remove this service.
 # It's not needed with the deployment type brokerapp but is needed for templating patches.
@@ -124,6 +131,7 @@ spec:
             privileged: false
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: {{$enableSudo}}
           env:
             - name: VDI_USER
               value: "{{.App}}"

--- a/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-statefulset.yaml.tmpl
+++ b/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-statefulset.yaml.tmpl
@@ -31,6 +31,14 @@
   {{- end}}
 {{- end}}
 
+{{- $enableSudo := true}}
+{{- if .AppParams.enableSudo }}
+  {{- if eq .AppParams.enableSudo "false"}}
+    {{- $enableSudo = false }}
+  {{- end}}
+{{- end}}
+
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -149,6 +157,7 @@ spec:
             privileged: false
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: {{$enableSudo}}
           env:
             - name: VDI_USER
               value: "{{.User}}"


### PR DESCRIPTION
Introduce a brokerappconfig param to control whether the desktop container can gain sudo privileges.

**Description**: control whether the desktop container can gain sudo privileges.
**Path**: spec.appParams.enableSudo
**Default value**: true
**Usage**
```yaml
#spec.appParams.enableSudo
spec:
 #appParams section
 appParams:
   - name: enableSudo
     default: "false"
```