### PR TITLE
Upgrade 1.22

### DIFF
--- a/examples/xfce-desktop/xfce-desktop-vdi-web-preview-gateway.yaml
+++ b/examples/xfce-desktop/xfce-desktop-vdi-web-preview-gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: xfce-desktop-vdi-web-preview-gateway

--- a/examples/xpra-desktop/xpra-desktop-vdi-web-preview-gateway.yaml
+++ b/examples/xpra-desktop/xpra-desktop-vdi-web-preview-gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: xpra-desktop-vdi-web-preview-gateway

--- a/infra/turn/cloudbuild.private-gke.yaml
+++ b/infra/turn/cloudbuild.private-gke.yaml
@@ -85,7 +85,7 @@ steps:
 
       # Add kustomize patch for Istio VirtualService to use the pod-broker-gateway.
       cat - > patch-coturn-web-gateway.yaml <<EOF
-      apiVersion: networking.istio.io/v1alpha3
+      apiVersion: networking.istio.io/v1beta1
       kind: VirtualService
       metadata:
         name: coturn-web

--- a/infra/turn/cloudbuild.public-gke.yaml
+++ b/infra/turn/cloudbuild.public-gke.yaml
@@ -64,7 +64,7 @@ steps:
 
       # Add kustomize patch for Istio VirtualService to use the pod-broker-gateway.
       cat - > patch-coturn-web-gateway.yaml <<EOF
-      apiVersion: networking.istio.io/v1alpha3
+      apiVersion: networking.istio.io/v1beta1
       kind: VirtualService
       metadata:
         name: coturn-web

--- a/manifests/brokerapp-base/deployment-user-bundle-manifests/resource-vdi-virtual-service.yaml.tmpl
+++ b/manifests/brokerapp-base/deployment-user-bundle-manifests/resource-vdi-virtual-service.yaml.tmpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}

--- a/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-virtual-service.yaml.tmpl
+++ b/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-virtual-service.yaml.tmpl
@@ -14,7 +14,7 @@
 
 {{- if eq .AppSpec.Type "statefulset" }}
 # [START pod_broker_virtual_service]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}

--- a/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-web-preview-ports.yaml.tmpl
+++ b/manifests/brokerapp-base/webrtc-bundle-manifests/resource-vdi-web-preview-ports.yaml.tmpl
@@ -32,7 +32,7 @@
 # ServiceEntry for web-preview URLs.
 # Required to do route based destinations and set-cookie redirect.
 ###
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
   name: {{.ServiceName}}-web-preview
@@ -48,7 +48,7 @@ spec:
     protocol: HTTP
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}-web-preview

--- a/manifests/node/gpu-driver-ubuntu.yaml
+++ b/manifests/node/gpu-driver-ubuntu.yaml
@@ -29,7 +29,7 @@ metadata:
     app: nvidia-driver-installer-ubuntu
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nvidia-driver-installer-ubuntu
   labels:
@@ -44,7 +44,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nvidia-driver-installer-ubuntu
   labels:

--- a/manifests/node/gpu-node-init.yaml
+++ b/manifests/node/gpu-node-init.yaml
@@ -21,7 +21,7 @@ metadata:
     app: gpu-node-init
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: gpu-node-init
   labels:
@@ -36,7 +36,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: gpu-node-init
   labels:


### PR DESCRIPTION
- istio api upgrade for `networking.istio.io` from `v1aplha3` to `v1beta1`
- upgrade api for `rbac.authorization.k8s.io` from `v1beta` to `v1`